### PR TITLE
prevent page transition if not saved on ios

### DIFF
--- a/frontend/src/views/BlogEditorV2.tsx
+++ b/frontend/src/views/BlogEditorV2.tsx
@@ -373,7 +373,7 @@ export const BlogEditorV2: FC = () => {
     document.body.style.overflow = mediaQuery.matches ? 'hidden' : 'auto'
     mediaQuery.addEventListener('change', onSizeChange)
 
-    const onLeave = (e: BeforeUnloadEvent | PageTransitionEvent | PopStateEvent): string | undefined => {
+    const onLeave = (e: BeforeUnloadEvent | PageTransitionEvent): string | undefined => {
       if (!isDirtyRef.current) {
         return
       }

--- a/frontend/src/views/BlogEditorV2.tsx
+++ b/frontend/src/views/BlogEditorV2.tsx
@@ -373,17 +373,19 @@ export const BlogEditorV2: FC = () => {
     document.body.style.overflow = mediaQuery.matches ? 'hidden' : 'auto'
     mediaQuery.addEventListener('change', onSizeChange)
 
-    const onBeforeUnload = (e: BeforeUnloadEvent): string | undefined => {
+    const onLeave = (e: BeforeUnloadEvent | PageTransitionEvent | PopStateEvent): string | undefined => {
       if (!isDirtyRef.current) {
         return
       }
       e.preventDefault()
       return ''
     }
-    window.addEventListener('beforeunload', onBeforeUnload)
+    window.addEventListener('beforeunload', onLeave)
+    window.addEventListener('pagehide', onLeave)
     return () => {
       mediaQuery.removeEventListener('change', onSizeChange)
-      window.removeEventListener('beforeunload', onBeforeUnload)
+      window.removeEventListener('beforeunload', onLeave)
+      window.removeEventListener('pagehide', onLeave)
     }
   }, [])
 


### PR DESCRIPTION
iOS has a bug that `beforeunload` does not work.
In this PR, to prevent unintentional leave from editor page while there is unsaved edits, `pagehide` event listener is registered.