### PR TITLE
Changed default visibility to author only

### DIFF
--- a/frontend/src/views/BlogEditorV2.tsx
+++ b/frontend/src/views/BlogEditorV2.tsx
@@ -182,7 +182,7 @@ export const BlogEditorV2: FC = () => {
   // entry info
   const [content, setContent] = useState<string>(entryInfo.entry?.content ?? '')
   const [blobs, setBlobs] = useState(entryInfo.entry?.blobs)
-  const [visibility, setVisibility] = useState(entryInfo.entry?.isDraft === true ? 'author' : (entryInfo.entry?.visibility ?? 'public'))
+  const [visibility, setVisibility] = useState(entryInfo.entry?.isDraft === true ? 'author' : (entryInfo.entry?.visibility ?? 'author'))
 
   const sessManager = useMemo(GenerateSessionManager, [])
 


### PR DESCRIPTION
Currently the default entry visibility is set to `public`.
However it has a risk that the users accidentally saves an article as public which is not ready for public or contains contents that the users want to reconsider.
This PR changes the default visibility to `author` to prevent accidentally setting public visibility.