### PR TITLE
add title length check before autosave

### DIFF
--- a/frontend/src/views/BlogEditorV2.tsx
+++ b/frontend/src/views/BlogEditorV2.tsx
@@ -419,6 +419,9 @@ export const BlogEditorV2: FC = () => {
           })
       }, PREVIEW_TIMER_MILLISECONDS)
     }
+    if (title === undefined || title.length === 0) {
+      return
+    }
     // auto save
     // save AUTOSAVE_TIMER_MILLISECONDS later since last change
     if (autosaveTimerRef.current !== undefined) {
@@ -496,7 +499,6 @@ export const BlogEditorV2: FC = () => {
       })
     } catch (err) {
       setToastContent({ message: `Failed to delete the entry (${(err as Error).message})`, severity: 'error' })
-    } finally {
       setIsBusy(false)
     }
   }, [isBusy, authorInfo.did, authorInfo.handle, authorInfo.pds, curProfile, entryInfo.rkey, requestAuth, router, sessManager, setToastContent])


### PR DESCRIPTION
The auto save is enabled even if the title length is zero.
This causes glitch of WhiteWInd viewing experience.
This PR adds a guard to check the title length before starting auto save.