### PR TITLE
Adjust main area layout

### DIFF
--- a/frontend/src/components/EntryHeroSection.tsx
+++ b/frontend/src/components/EntryHeroSection.tsx
@@ -27,7 +27,7 @@ export const EntryHeroSection: FC<IEntryHeroSectionProps> = ({ title, did, handl
   const cssProps = { '--image-url': `url(${ogpUrl ?? ''})` }
   const backgroundStyle = !isOgpEmpty ? cssProps as CSSProperties : undefined
   const backgroundClassName = !isOgpEmpty ? 'bg-[image:var(--image-url)] bg-cover bg-center bg-no-repeat' : undefined
-  const mainClassName = `grid grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 ${!isOgpEmpty ? 'backdrop-blur-sm backdrop-brightness-50' : ''}`
+  const mainClassName = `flex justify-center ${!isOgpEmpty ? 'backdrop-blur-sm backdrop-brightness-50' : ''}`
   const titleFontClassName = `font-semibold text-2xl sm:text-4xl ${!isOgpEmpty ? 'text-white' : 'text-gray-700'}`
   const handleClassName = `text-md sm:text-lg ${!isOgpEmpty ? 'text-gray-300' : 'text-gray-400'}`
   const subtitleClassName = `w-fit text-md sm:text-lg ${!isOgpEmpty ? 'text-gray-300' : 'text-gray-400'}`
@@ -35,11 +35,8 @@ export const EntryHeroSection: FC<IEntryHeroSectionProps> = ({ title, did, handl
   return (
     <div style={backgroundStyle} className={backgroundClassName}>
       <div className={mainClassName}>
-        <div className='hidden xl:block grow'>
-          <div className='pr-4 flex justify-end sticky top-6' />
-        </div>
         <div
-          className='col-span-3 lg:col-span-4 xl:col-span-3 min-h-[20vh] sm:min-h-[30vh] px-4 pt-4 flex justify-center items-center'
+          className='min-h-[20vh] sm:min-h-[30vh] max-w-[800px] lg:max-w-[1225px] px-4 pt-4 flex justify-center items-center'
         >
           <div className='flex flex-col w-fit'>
             <h1 className={titleFontClassName}>{titleLines.map(
@@ -56,7 +53,6 @@ export const EntryHeroSection: FC<IEntryHeroSectionProps> = ({ title, did, handl
             </div>
           </div>
         </div>
-        <div className='hidden xl:block px-1 py-4 min-w-10' />
       </div>
     </div>
   )

--- a/frontend/src/components/LeftOverlayBlogViewer.tsx
+++ b/frontend/src/components/LeftOverlayBlogViewer.tsx
@@ -30,7 +30,7 @@ const LeftOverlayBlogViewer: React.FC<LeftOverlayProps> = () => {
   }
 
   return (
-    <div className='flex flex-col justify-center items-center'>
+    <div className='flex flex-col items-center'>
       <BlueskyShareIconButton />
       <TwitterShareIconButton />
       <ThreadsShareIconButton />

--- a/frontend/src/components/ThreeColumnBlogView.tsx
+++ b/frontend/src/components/ThreeColumnBlogView.tsx
@@ -8,31 +8,43 @@ export interface ThreeColumnViewProps {
   center?: React.ReactNode
   right?: React.ReactNode
   hero?: React.ReactNode
+  ogpUrl?: string
   disableHeader?: boolean
 }
 
-const ThreeColumnBlogView: React.FC<ThreeColumnViewProps> = ({ left, center, right, hero, disableHeader }) => {
+const ThreeColumnBlogView: React.FC<ThreeColumnViewProps> = ({ left, center, right, ogpUrl, hero, disableHeader }) => {
   return (
-    <div className='flex flex-col h-screen'>
+    <div className='flex flex-col h-screen'> {/** header and others */}
       {disableHeader !== true && <EntryPageHeader />}
       {hero}
-      <div className='grid grid-cols-3 xl:grid-cols-5'>
-        <div className='hidden xl:block grow'>
-          <div className='h-[90vh] pr-4 flex justify-end sticky top-6'>
-            {left}
+      <div className='w-full flex-col'> {/** footer and others */}
+        <div className='flex w-full justify-center'> {/** main */}
+          <div className='hidden py-4 xl:block xl:flex xl:flex-col'>
+            <div className='h-[90vh] pr-4 flex justify-end sticky top-20'>
+              {left}
+            </div>
+          </div>
+          <div className='px-4 py-4 w-full max-w-[800px]'>{/* main content area */}
+            {center}
+          </div>
+          <div className='hidden lg:block px-1 py-4 min-w-10'>
+            <div className='sticky top-20'>
+              {right}
+            </div>
           </div>
         </div>
-        <div className='grow col-span-3 px-4 md:px-20 xl:px-4 py-4'>{/* main content area */}
-          {center}
-        </div>
-        <div className='hidden xl:block px-1 py-4 min-w-10'>
-          <div className='sticky top-20'>
-            {right}
-          </div>
-        </div>
+        <Footer />
       </div>
-      <Footer />
     </div>
   )
 }
 export default ThreeColumnBlogView
+
+// {/** dummy area */}
+// <div className='min-h-[calc(20vh+60px)] sm:min-h-[calc(30vh+60px)] flex justify-center items-center'>
+//   <div className='flex flex-col h-full justify-center items-center'>
+//     <h1 className='font-semibold text-2xl sm:text-4xl'>
+//       test
+//     </h1>
+//   </div>
+// </div>

--- a/frontend/src/services/DocProvider.tsx
+++ b/frontend/src/services/DocProvider.tsx
@@ -33,7 +33,11 @@ const production = {
   components: {
     script: () => <></>,
     ul: (props: JSX.IntrinsicElements['ul']) => <ul {...props} className='list-disc text-gray-700' />,
-    ol: (props: JSX.IntrinsicElements['ol']) => <ol {...props} className='list-decimal text-gray-700' />
+    ol: (props: JSX.IntrinsicElements['ol']) => <ol {...props} className='list-decimal text-gray-700' />,
+    p: (props: JSX.IntrinsicElements['p']) => <p {...props} className='leading-7' />,
+    iframe: (props: JSX.IntrinsicElements['iframe']) => {
+      return <div className='w-full flex justify-center'><iframe {...props} className='max-w-full' /></div>
+    }
   }
 }
 
@@ -89,11 +93,13 @@ const GenerateRehypeScriptDetect = (scripts: string[]): Plugin<any, Root, Node> 
   return rehypeScriptDetector
 }
 
-const recursiveGetBlobReplacer = (child: Node): void => {
+const recursiveModifier = (child: Node): void => {
   if (child.type !== 'element') {
     return
   }
   const elem = child as Element
+
+  // Replace image URL that starts with com.atproto.sync.getBlob with our CDN one
   const src = elem.properties.src
   if (src !== undefined && typeof src === 'string') {
     const replaced = GetReplacedGetBlobURL(src)
@@ -101,12 +107,12 @@ const recursiveGetBlobReplacer = (child: Node): void => {
       elem.properties.src = replaced
     }
   }
-  elem.children.forEach(child => recursiveGetBlobReplacer(child))
+  elem.children.forEach(child => recursiveModifier(child))
 }
 
 const rehypeGetBlobReplacer: Plugin<any, Root, Node> = () => {
   return (tree) => {
-    tree.children.forEach(child => recursiveGetBlobReplacer(child))
+    tree.children.forEach(child => recursiveModifier(child))
   }
 }
 


### PR DESCRIPTION
So far, the main area size was unlimited and line height was too small, which resulted in too large size, which caused the readability issue.
In addition, the width of the iframe embeddings did not respect the main area size.
It often caused broken layout on mobile.
This PR fixes these issues.