### PR TITLE
Link fixes to blog post comments

### DIFF
--- a/frontend/src/components/bskyembed/src/components/blogEntry.tsx
+++ b/frontend/src/components/bskyembed/src/components/blogEntry.tsx
@@ -30,7 +30,7 @@ export function BlogEntry ({ entry, uri, profile }: BlogEntryProps): ReactNode {
     <Container>
       <div className='flex-1 flex-col flex gap-2'>
         <div className='flex gap-2.5 items-center cursor-pointer'>
-          <Link href={`/profile/${aturi.hostname}`} className='rounded-full'>
+          <Link href={`https://whtwnd.com/${aturi.hostname}`} className='rounded-full'>
             <div className='w-10 h-10 overflow-hidden rounded-full bg-neutral-300 shrink-0'>
               <img
                 src={profile?.avatar}
@@ -39,14 +39,14 @@ export function BlogEntry ({ entry, uri, profile }: BlogEntryProps): ReactNode {
           </Link>
           <div>
             <Link
-              href={`/profile/${aturi.hostname}`}
+              href={`https://whtwnd.com/${aturi.hostname}`}
               className='font-bold text-[17px] leading-5 line-clamp-1 hover:underline underline-offset-2 decoration-2'
             >
               <p>{profile?.displayName}</p>
             </Link>
             <p>
               <Link
-                href={`/profile/${aturi.hostname}`}
+                href={`https://whtwnd.com/${aturi.hostname}`}
                 className='text-[15px] text-textLight hover:underline'
               >
                 @{profile?.handle}

--- a/frontend/src/components/bskyembed/src/components/blogEntry.tsx
+++ b/frontend/src/components/bskyembed/src/components/blogEntry.tsx
@@ -24,7 +24,7 @@ export function BlogEntry ({ entry, uri, profile }: BlogEntryProps): ReactNode {
   }, [entry])
 
   const aturi = new AtUri(uri)
-  const href = `/${aturi.hostname}/${entry.title !== undefined ? `entries/${entry.title}` : aturi.rkey}`
+  const href = `/${aturi.hostname}/${entry.title !== undefined ? `entries/${encodeURIComponent(entry.title)}` : aturi.rkey}`
 
   return (
     <Container>

--- a/frontend/src/components/bskyembed/src/components/blogEntry.tsx
+++ b/frontend/src/components/bskyembed/src/components/blogEntry.tsx
@@ -52,7 +52,7 @@ export function BlogEntry ({ entry, uri, profile }: BlogEntryProps): ReactNode {
                 @{profile?.handle}
               </Link>
               ・
-              <Link href={href}>
+              <Link href={`https://whtwnd.com${href}`}>
                 <time
                   dateTime={entry.createdAt !== undefined ? new Date(entry.createdAt).toISOString() : ''}
                   className='text-textLight mt-1 text-sm hover:underline'


### PR DESCRIPTION
* Fix an issue where a blog comment's timestamp links to Bluesky, where the post doesn't exist
* Fix an issue where special characters in blog comment links (such as question marks) are not escaped correctly
* Makes blog comments link to WhiteWind profile instead of Bluesky profile

I haven't been able to test this, unfortunately, but it should work.