### PR TITLE
Add subtitle to entry lexicon schema

### DIFF
--- a/lexicons/com/whtwnd/blog/entry.json
+++ b/lexicons/com/whtwnd/blog/entry.json
@@ -24,6 +24,10 @@
                         "type": "string",
                         "maxLength": 1000
                     },
+                    "subtitle": {
+                        "type": "string",
+                        "maxLength": 1000
+                    },
                     "ogp": {
                         "type": "ref",
                         "ref": "com.whtwnd.blog.defs#ogp"


### PR DESCRIPTION
This adds optional subtitles into the entry lexicon. This is, to my knowledge, the only major blogging feature missing from the lexicon. 
Closes #118 